### PR TITLE
Feature/add build process

### DIFF
--- a/.circleci/announceDeployment.sh
+++ b/.circleci/announceDeployment.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+applicationName=$1
+targetEnvironment=$2
+publishedArtifact=$3
+
+payload=$(
+cat <<EOM
+{
+    "attachments": [
+        {
+            "fallback": "$applicationName succesfully deployed to $targetEnvironment.",
+            "color": "#33CC66",
+            "pretext": "$applicationName succesfully deployed to $targetEnvironment.",
+            "title": "$CIRCLE_PROJECT_REPONAME",
+            "title_link": "https://circleci.com/workflow-run/$CIRCLE_WORKFLOW_WORKSPACE_ID",
+            "text": "$publishedArtifact",
+            "ts": $(date '+%s')
+        }
+    ]
+}
+EOM
+)
+
+curl -X POST --data-urlencode payload="$payload" "$SLACK_WEBHOOK_URL"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Create .pypirc
+          name: Create .pypirc and append CircleCI build number as version
           command: |
             chmod +x .circleci/pypirc.sh && .circleci/pypirc.sh
             touch version.py
-            echo "__version__ = 'staging-0.1.$CIRCLE_BUILD_NUM'" > version.py
+            echo "__version__ = '0.1.$CIRCLE_BUILD_NUM-staging'" > version.py
       - run:
           name: Install requirements
           command: |
@@ -38,7 +38,7 @@ jobs:
             source ./env/bin/activate
             pip3 install -r requirements.txt
       - run:
-          name: Append circleCI build number to version
+          name: Git config
           command: |
             git config user.email "devops@pillar.io"
             git config user.name "Issabot"
@@ -47,6 +47,19 @@ jobs:
           command: |
             python3 setup.py sdist upload -r local
             chmod +x .circleci/announceRelease.sh && .circleci/announceRelease.sh "gassstation-express-oracle-staging" "gassstation-express-oracle-staging:$CIRCLE_BUILD_NUM"
+      - run:
+          name: Push txt file to S3 bucket
+          command: |
+            touch gasstation-express-oracle.txt
+            echo "gasstation-express-oracle@0.1.$CIRCLE_BUILD_NUM-staging" > gasstation-express-oracle.txt
+            export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
+            aws s3 cp gasstation-express-oracle.txt $STAGING_RELEASE_BUCKET
+      - run:
+          name: Announce Deployment
+          command: |
+            chmod +x .circleci/announceDeployment.sh
+            .circleci/announceDeployment.sh "gasstation-express-oracle" "Staging" "$(cat ./gasstation-express-oracle.txt)"
 
   publish-prod:
     working_directory: ~/gasstation-express-oracle
@@ -55,7 +68,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Create .pypirc
+          name: Create .pypirc and append CircleCI build number as version
           command: |
             chmod +x .circleci/pypirc.sh && .circleci/pypirc.sh
             touch version.py
@@ -67,7 +80,7 @@ jobs:
             source ./env/bin/activate
             pip3 install -r requirements.txt
       - run:
-          name: Append circleCI build number to version
+          name: Git config
           command: |
             git config user.email "devops@pillar.io"
             git config user.name "Issabot"
@@ -76,6 +89,19 @@ jobs:
           command: |
             python3 setup.py sdist upload -r local
             chmod +x .circleci/announceRelease.sh && .circleci/announceRelease.sh "gassstation-express-oracle" "gassstation-express-oracle:$CIRCLE_BUILD_NUM"
+      - run:
+          name: Push txt file to S3 bucket
+          command: |
+            touch gasstation-express-oracle.txt
+            echo "gasstation-express-oracle@0.1.$CIRCLE_BUILD_NUM" > gasstation-express-oracle.txt
+            export AWS_ACCESS_KEY_ID=$PRODUCTION_AWS_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$PRODUCTION_AWS_SECRET_ACCESS_KEY
+            aws s3 cp gasstation-express-oracle.txt $PRODUCTION_RELEASE_BUCKET
+      - run:
+          name: Announce Deployment
+          command: |
+            chmod +x .circleci/announceDeployment.sh
+            .circleci/announceDeployment.sh "gasstation-express-oracle" "Production" "$(cat ./gasstation-express-oracle.txt)"
 
 workflows:
   version: 2
@@ -88,7 +114,7 @@ workflows:
           filters:
             branches:
               only:
-                  - develop
+                  - feature/add-build-process
       - publish-prod:
           requires:
              - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ workflows:
           filters:
             branches:
               only:
-                  - feature/add-build-process
+                  - develop
       - publish-prod:
           requires:
              - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - checkout
       - run:
           name: Install AWS CLI
-          command: pip install awscli
+          command: pip install awscli --upgrade --user
       - run:
           name: Create .pypirc and append CircleCI build number as version
           command: |
@@ -70,6 +70,9 @@ jobs:
       - image: circleci/python:3.6.7
     steps:
       - checkout
+      - run:
+          name: Install AWS CLI
+          command: pip install awscli --upgrade --user
       - run:
           name: Create .pypirc and append CircleCI build number as version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             echo "gasstation-express-oracle@0.1.$CIRCLE_BUILD_NUM-staging" > gasstation-express-oracle.txt
             export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
-            aws s3 cp gasstation-express-oracle.txt $STAGING_RELEASE_BUCKET
+            /home/circleci/.local/bin/aws s3 cp gasstation-express-oracle.txt $STAGING_RELEASE_BUCKET
       - run:
           name: Announce Deployment
           command: |
@@ -102,7 +102,7 @@ jobs:
             echo "gasstation-express-oracle@0.1.$CIRCLE_BUILD_NUM" > gasstation-express-oracle.txt
             export AWS_ACCESS_KEY_ID=$PRODUCTION_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$PRODUCTION_AWS_SECRET_ACCESS_KEY
-            aws s3 cp gasstation-express-oracle.txt $PRODUCTION_RELEASE_BUCKET
+            /home/circleci/.local/bin/aws s3 cp gasstation-express-oracle.txt $PRODUCTION_RELEASE_BUCKET
       - run:
           name: Announce Deployment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install AWS CLI
+          command: pip install awscli
+      - run:
           name: Create .pypirc and append CircleCI build number as version
           command: |
             chmod +x .circleci/pypirc.sh && .circleci/pypirc.sh


### PR DESCRIPTION
This should complete the CircleCI part of the build process for this repo. Package, publish to jfrog, create and copy text file to the appropriate s3 bucket.

@t-j-turner @Beryllium26 reason I am adding a **staging**  string to the staging text file is to distinguish the packages on jfrog (develop-staging env., master-prod env.) Please advise if this seems okay to you in order to pull and deploy the packages.

Also as you can see, there is a **production** job for automating the text file to s3 push, please suggest/comment about that as well.